### PR TITLE
Fix typo in Utf8JsonReaderExtensions (OSK-3)

### DIFF
--- a/src/OSK.Extensions.SystemTextJson.Common/Utf8JsonReaderExtensions.cs
+++ b/src/OSK.Extensions.SystemTextJson.Common/Utf8JsonReaderExtensions.cs
@@ -21,13 +21,14 @@ namespace OSK.Extensions.SystemTextJson.Common
         public static bool TryFindPropertyValue(this Utf8JsonReader reader, string propertyName,
             out Utf8JsonReader copiedReader)
         {
+            // Copy original reader to prevent undesired token consumption
             copiedReader = reader;
-            if (reader.TokenType != JsonTokenType.StartObject)
+            if (copiedReader.TokenType != JsonTokenType.StartObject)
             {
                 return false;
             }
 
-            var startingDepth = reader.CurrentDepth;
+            var startingDepth = copiedReader.CurrentDepth;
             while (copiedReader.TokenType != JsonTokenType.EndObject || copiedReader.CurrentDepth != startingDepth)
             {
                 copiedReader.Read();

--- a/src/OSK.Extensions.SystemTextJson.Common/Utf8JsonReaderExtensions.cs
+++ b/src/OSK.Extensions.SystemTextJson.Common/Utf8JsonReaderExtensions.cs
@@ -28,23 +28,23 @@ namespace OSK.Extensions.SystemTextJson.Common
             }
 
             var startingDepth = reader.CurrentDepth;
-            while (reader.TokenType != JsonTokenType.EndObject || reader.CurrentDepth != startingDepth)
+            while (copiedReader.TokenType != JsonTokenType.EndObject || copiedReader.CurrentDepth != startingDepth)
             {
-                reader.Read();
-                switch (reader.TokenType)
+                copiedReader.Read();
+                switch (copiedReader.TokenType)
                 {
                     case JsonTokenType.PropertyName:
-                        var currentPropertyName = reader.GetString();
+                        var currentPropertyName = copiedReader.GetString();
                         if (currentPropertyName == propertyName)
                         {
-                            // Get to the property value for consumer read preference
-                            reader.Read();
+                            // Let the consumer read the current property value as they desire
+                            copiedReader.Read();
                             return true;
                         }
                         break;
                 }
 
-                reader.Skip();
+                copiedReader.Skip();
             }
 
             return false;


### PR DESCRIPTION
Motivation
----
A typo is causing the original Utf8JsonReader to be consumed rather than the copy

Modifications
----
* Fix typo

Result
----
The copied Utf8JsonReader is used for property seeking, rather than the original

Fixes #3