### PR TITLE
Add Case sensitive overload method (OSK-7)

### DIFF
--- a/src/OSK.Extensions.SystemTextJson.Common/Utf8JsonReaderExtensions.cs
+++ b/src/OSK.Extensions.SystemTextJson.Common/Utf8JsonReaderExtensions.cs
@@ -5,7 +5,7 @@ namespace OSK.Extensions.SystemTextJson.Common
     public static class Utf8JsonReaderExtensions
     {
         /// <summary>
-        /// Attempts to find a property that matches the provided property name and returns the associated value
+        /// Attempts to find a property that matches the provided property name and returns the associated value, and respects property case sensitivity
         /// </summary>
         /// <param name="reader">The reader to read the json data from</param>
         /// <param name="propertyName">The property name to seek</param>
@@ -18,6 +18,24 @@ namespace OSK.Extensions.SystemTextJson.Common
         /// Note 2: The returned reader will be at the point of the property value for the consumer to read, if found.
         /// </remarks>
         public static bool TryFindPropertyValue(this Utf8JsonReader reader, string propertyName,
+            out Utf8JsonReader copiedReader)
+            => reader.TryFindPropertyValue(propertyName, false, out copiedReader);
+
+        /// <summary>
+        /// Attempts to find a property that matches the provided property name and returns the associated value
+        /// </summary>
+        /// <param name="reader">The reader to read the json data from</param>
+        /// <param name="propertyName">The property name to seek</param>
+        /// <param name="ignoreCaseSensitivity">Determines if the reader will ignore or respect case sensitivty when comparing property names</param>
+        /// <param name="copiedReader">The copied Utf8JsonReader at the point where the property was found, if it exists.</param>
+        /// <returns>True if the property is found, false if not.</returns>
+        /// <remarks>
+        /// Note 1: The reader that is used is not directly consumed as a copy is made prior to seek for the property.
+        /// This allows deserialization to continue as normal.
+        /// <br/><br/>
+        /// Note 2: The returned reader will be at the point of the property value for the consumer to read, if found.
+        /// </remarks>
+        public static bool TryFindPropertyValue(this Utf8JsonReader reader, string propertyName, bool ignoreCaseSensitivity,
             out Utf8JsonReader copiedReader)
         {
             // Copy original reader to prevent undesired token consumption
@@ -35,7 +53,8 @@ namespace OSK.Extensions.SystemTextJson.Common
                 {
                     case JsonTokenType.PropertyName:
                         var currentPropertyName = copiedReader.GetString();
-                        if (currentPropertyName == propertyName)
+                        if (string.Equals(propertyName, currentPropertyName, 
+                            ignoreCaseSensitivity ? System.StringComparison.OrdinalIgnoreCase : System.StringComparison.Ordinal))
                         {
                             // Let the consumer read the current property value as they desire
                             copiedReader.Read();


### PR DESCRIPTION
Motivation
----
The current extension for finding a property name in a JSON object is case sensitive and will fail if properties are not exactly the same

Modifications
----
* Added new overload for case insensitive extension and kept original logic consistent to prevent breaking change

Result
----
A new method for finding property names with Utf8JsonReaderExtensions is available that can ignore case sensitivity

Fixes #7